### PR TITLE
Changed clone instructions to be less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A product monitor to check the health of connected TV products and services.
 
 To run locally:
 ```
-git clone git@github.com:johnbeech/connected-tv-app-monitor.git
+git clone git@github.com:connected-tv/connected-tv-app-monitor.git
 npm install
 node server.js
 ```


### PR DESCRIPTION
The cloning instructions referred to the johnbeech account, not the connected-tv organisation, though the johnbeech URI works, I thought it was slightly confusing